### PR TITLE
Add JSON format output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The simulator has several flags to get more information out of the simulation, t
 				Maximum number of steps
 		--limit [true]:
 				Limit number of steps
-		--just_steps [false]:
-        		Prints out just the number of steps
+		--json [false]:
+        		Outputs the result in a JSON format (overrides --output)
 
 ## Examples
 Try running the following commands to see the simulator working

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The simulator has several flags to get more information out of the simulation, t
 				Maximum number of steps
 		--limit [true]:
 				Limit number of steps
+		--just_steps [false]:
+        		Prints out just the number of steps
 
 ## Examples
 Try running the following commands to see the simulator working

--- a/turing.cc
+++ b/turing.cc
@@ -351,6 +351,8 @@ DEFINE_bool(output, true,
     "Output the final content of the TM tapes");
 DEFINE_int(max_steps, 10000000,
     "Maximum number of steps");
+DEFINE_bool(just_steps, false,
+  "Prints out just the number of steps");
 
 int main(int argc, char** argv) {
   REGISTER_FLAG(argc, argv, show_machine);
@@ -359,6 +361,7 @@ int main(int argc, char** argv) {
   REGISTER_FLAG(argc, argv, output);
   REGISTER_FLAG(argc, argv, max_steps);
   REGISTER_FLAG(argc, argv, limit);
+  REGISTER_FLAG(argc, argv, just_steps);
 
   if(argc < 2) {
     std::cout << "Usage" << std::endl <<
@@ -431,6 +434,12 @@ int main(int argc, char** argv) {
           "halting state");
     }
     n_steps--;
+
+    if (FLAG_just_steps) {
+      std::cout << n_steps;
+      return 0;
+    }
+
     LOG_INFO("N steps: " << n_steps);
     LOG_INFO("Final State: " << machine2.current_state->name << "(" << machine2.state_word() << ")");
     if(machine2.accepted()) {

--- a/turing.cc
+++ b/turing.cc
@@ -351,8 +351,10 @@ DEFINE_bool(output, true,
     "Output the final content of the TM tapes");
 DEFINE_int(max_steps, 10000000,
     "Maximum number of steps");
-DEFINE_bool(just_steps, false,
-  "Prints out just the number of steps");
+DEFINE_bool(json, false,
+  "Outputs the result in a JSON format (overrides --output)");
+DEFINE_bool(help, false,
+    "Show a list of command-line options");
 
 int main(int argc, char** argv) {
   REGISTER_FLAG(argc, argv, show_machine);
@@ -361,13 +363,14 @@ int main(int argc, char** argv) {
   REGISTER_FLAG(argc, argv, output);
   REGISTER_FLAG(argc, argv, max_steps);
   REGISTER_FLAG(argc, argv, limit);
-  REGISTER_FLAG(argc, argv, just_steps);
+  REGISTER_FLAG(argc, argv, json);
+  REGISTER_FLAG(argc, argv, help);
 
-  if(argc < 2) {
+  if(argc < 2 || FLAG_help) {
     std::cout << "Usage" << std::endl <<
       "turing <tm_file> <input_word>" << std::endl;
     FLAGHELP();
-    return 1;
+    return FLAG_help ? 0 : 1;
   }
   std::string filename(argv[1]);
 	std::string word;
@@ -435,8 +438,25 @@ int main(int argc, char** argv) {
     }
     n_steps--;
 
-    if (FLAG_just_steps) {
-      std::cout << n_steps;
+    if(FLAG_json) {
+      std::cout
+        << "{"
+        << "\"steps\": " << n_steps << ", "
+        << "\"final_state\": " << "\"" << machine2.current_state->name << "\"" << ", "
+        << "\"final_word\": " << "\"" << machine2.state_word() << "\"" << ", "
+        << "\"accepted\": " << (machine2.accepted() ? "true" : "false") << ", "
+        << "\"tapes\": "
+        << "["
+      ;
+
+      for (size_t i = 0; i < machine2.tapes.size(); i++) {
+        if (i != 0) std::cout << ", ";
+        std::cout << "\"" << machine2.tapes[i].content() << "\"";
+      }
+
+      std::cout << "]";
+      std::cout << "}";
+
       return 0;
     }
 
@@ -454,4 +474,5 @@ int main(int argc, char** argv) {
       }
     }
   }
+  return 0;
 }

--- a/utils.h
+++ b/utils.h
@@ -33,10 +33,9 @@ Strings
 #include <string>
 
 bool pathIsDir(const std::string& filePath) {
-  int status;
   struct stat st_buf;
+  stat(filePath.c_str(), &st_buf);
 
-  status = stat (filePath.c_str(), &st_buf);
   return S_ISDIR(st_buf.st_mode);
 }
 
@@ -79,7 +78,7 @@ std::vector<std::string> vGlob(const std::string& pattern) {
   //Glob.. GLOB_TILDE tells the globber to expand "~" in the pattern to the home directory
   glob(pattern.c_str(), GLOB_TILDE, NULL, &globbuf);
 
-  for (int i = 0; i < globbuf.gl_pathc; ++i) {
+  for (size_t i = 0; i < globbuf.gl_pathc; ++i) {
     fileList.push_back(globbuf.gl_pathv[i]);
   }
   

--- a/utils.h
+++ b/utils.h
@@ -61,6 +61,7 @@ std::vector<std::string> split(const std::string &s, char delim) {
     return elems;
 }
 
+#ifndef __MINGW32__
 /*
 Vector Glob
 */
@@ -88,6 +89,7 @@ std::vector<std::string> vGlob(const std::string& pattern) {
 
   return fileList;
 }
+#endif
 
 /*
 FLAGS


### PR DESCRIPTION
With this new option, you output the results in a JSON format, which allows you to capture that output and use it as you please, kind of like a poor man's API.

For example, I use it in Python to perform multiple tests on a TM, in order to compute its complexity through the Finite difference method.  
I can just write:
```python
json.loads(subprocess.check_output([TURING_EXEC, file, input, "--json"]))
```
and get the data for that iteration, in a Python dictionary.

I also fixed the compiler warnings.